### PR TITLE
Fixed Font Styles for Maps, Buttons, Sliders

### DIFF
--- a/server.R
+++ b/server.R
@@ -230,7 +230,7 @@ tabPanelServer <- function(geo_type) {
             options = pathOptions(pane = "layer1"), # place these polygons on the upper pane
             label = ~lapply(labelText, htmltools::HTML), # custom label text displayed in a tooltip on hover 
             labelOptions = labelOptions( 
-              style=list("font-size" = sprintf("%spx", APP_FONT_SIZE-2), "font-family"=APP_FONT)
+              style=list("font-size" = sprintf("%spx", APP_FONT_SIZE-2))
             ) # set font size for the tooltips a bit smaller than in the rest of app
           ) %>% hideGroup(group = yrdfs[[yr]]$GEOID) %>% # hide these polygons initially
           

--- a/server.R
+++ b/server.R
@@ -230,7 +230,7 @@ tabPanelServer <- function(geo_type) {
             options = pathOptions(pane = "layer1"), # place these polygons on the upper pane
             label = ~lapply(labelText, htmltools::HTML), # custom label text displayed in a tooltip on hover 
             labelOptions = labelOptions( 
-              style=list("font-size" = sprintf("%spx", APP_FONT_SIZE-2))
+              style=list("font-size" = sprintf("%spx", APP_FONT_SIZE-2), "font-family"=APP_FONT)
             ) # set font size for the tooltips a bit smaller than in the rest of app
           ) %>% hideGroup(group = yrdfs[[yr]]$GEOID) %>% # hide these polygons initially
           

--- a/www/test_theme.css
+++ b/www/test_theme.css
@@ -55,3 +55,22 @@
 body{
   font-family:"Open Sans";
 }
+
+/* Leaflet Font Changes */
+/* Legend */
+.info.legend.leaflet-control{
+    font-family: "Open Sans";
+}
+/* Tooltips */
+.leaflet-tooltip {
+   font-family:"Open Sans";
+}
+button{
+  font-family:"Open Sans";
+}
+span{
+  font-family:"Open Sans";
+}
+
+
+


### PR DESCRIPTION
Added a couple of css lines for the leaflet items (legend, tooltip), span elements (like slider), and buttons to all be Open Sans.