### PR TITLE
dynamically update selected-polygon tooltips

### DIFF
--- a/global.R
+++ b/global.R
@@ -68,12 +68,11 @@ pivot_summarise <- function(df, cats, summary_expr, id_columns) {
 
 #' helps update labels on pre-existing polygons
 #' Source: https://github.com/rstudio/leaflet/issues/496#issuecomment-871405207
-#' Author: Matt Harris (https://github.com/mrecos)
+#' Authors: Github users timelyportfolio, martinzuba, and mrecos
 setShapeLabel <- function( map, data = getMapData(map), layerId,
                            label = NULL,
                            options = NULL
 ){
-  cat("in setShapeLabel","\n")
   options <- c(list(layerId = layerId),
                options,
                filterNULL(list(label = label


### PR DESCRIPTION
fixes #53 by using the setShapeLabels function on the selected-polygons layer in response to the year being changed by the user. Moves the code that defines tooltip labels out of the indicator observer and into the areas_summary_df reactive, preserving the existing tooltip functionality on non-selected polygons, and then adds a line to the yearSelect observer to filter areas_summary_df to the selected year and apply its label text to the labels of the selected-polygon layer, fixing the issue with the selected-polygon tooltips.